### PR TITLE
Fix alternating name validity tests failing

### DIFF
--- a/api.js
+++ b/api.js
@@ -34,7 +34,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
   // The olde General Valid Name regex. In the off-chance it's decided that
   // emojis should be allowed (or whatever) in channel/user/etc names, this
   // regex can be updated.
-  const generalValidNameRegex = /^[a-zA-Z0-9_-]+$/g
+  const isNameValid = name => /^[a-zA-Z0-9_-]+$/g.test(name)
 
   const sendToAllSockets = function(evt, data) {
     for (const socket of connectedSocketsMap.keys()) {
@@ -346,10 +346,10 @@ module.exports = async function attachAPI(app, {wss, db}) {
     ],
 
     requireNameValid: (nameVar, errorFieldName = null) => [
-      async function(request, response, next) {
+      function(request, response, next) {
         const name = request[middleware.vars][nameVar]
 
-        if (generalValidNameRegex.test(name) === false) {
+        if (isNameValid(name) === false) {
           response.status(400).end(JSON.stringify({
             // Totally cheating here - this is so that it responds with
             // "username invalid" rather than, e.g., "name invalid", when


### PR DESCRIPTION
Before:

```js
for (let i = 0; i < 100; i++) {
  console.log(generalValidNameRegex.test('john'))
}
```

```
true
false
true
false
true
false
true
false
...
```

After:

```js
for (let i = 0; i < 100; i++) {
  cosnole.log(isNameValid('john'))
}
```

```
true
true
true
true
true
true
true
true
...
```

See MDN on [RegExp.prototype.test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#Description). Particularly:

> `test()` called multiple times on the same global regular expression instance will advance past the previous match.

Surprise, surprise, `.test` has side effects.. JavaScript was a mistake :upside_down_face: