### PR TITLE
Add account settings page/api endpoint and user profile pictures (avatars)

### DIFF
--- a/api.js
+++ b/api.js
@@ -53,7 +53,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
   }
 
   const emailToAvatarURL = memoize(email =>
-    `http://cdn.libravatar.org/avatar/${email ? md5(email) : ''}?d=retro`)
+    `https://seccdn.libravatar.org/avatar/${email ? md5(email) : ''}?d=retro`)
 
   const getUserBySessionID = async function(sessionID) {
     const session = await db.sessions.findOne({_id: sessionID})

--- a/api.js
+++ b/api.js
@@ -1002,6 +1002,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       response.status(200).end(JSON.stringify({
         success: true,
+        avatarURL: emailToAvatarURL(email),
       }))
     }
   ])

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "fix-whitespace": "^1.0.3",
+    "memoizee": "^0.4.11",
     "multer": "^1.3.0",
     "nedb": "^1.8.0",
     "nedb-promise": "^2.0.1",

--- a/site/js/app.css
+++ b/site/js/app.css
@@ -59,3 +59,94 @@ body {
 .wiggle {
   animation: 3s infinite normal wiggle;
 }
+
+.page {
+  padding: 36px;
+  height: 100%;
+  overflow-y: auto;
+
+  & > h1 {
+    margin-top: 0;
+
+    font-size: 32px;
+    color: var(--gray-100);
+
+    letter-spacing: -1px;
+
+    & > .subtitle {
+      color: var(--gray-300);
+      font-size: 24px;
+    }
+  }
+}
+
+.styled-input {
+  margin-bottom: 16px;
+
+  & label {
+    display: block;
+    color: var(--gray-300);
+
+    font-weight: bold;
+    font-size: 16px;
+
+    text-transform: uppercase;
+    margin-bottom: 4px;
+    margin-left: 13px;
+
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
+  }
+
+  & input {
+    width: 280px;
+    padding: 13px 16px;
+
+    font-family: inherit;
+    font-size: 18px;
+
+    color: var(--gray-100);
+    background: var(--gray-900);
+
+    border: 0;
+    border-bottom: 1px solid var(--gray-500);
+    &:focus { border-color: var(--blue); }
+
+    &[disabled] {
+      cursor: not-allowed;
+      background: var(--gray-700);
+      opacity: .8;
+    }
+  }
+}
+
+.styled-button {
+  padding: 10px 16px;
+  margin-left: 3px;
+
+  background: var(--blue);
+  border-radius: 4px;
+  border: none;
+
+  font-size: 14px;
+  color: var(--gray-900);
+
+  cursor: pointer;
+
+  &.no-bg {
+    color: var(--blue);
+    background: transparent;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+a:any-link.link {
+  color: var(--blue);
+  text-decoration: underline;
+}
+

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -11,6 +11,7 @@ Object.assign(window, { util }) // publish util for debugging/experimenting
 const messages = require('./components/messages')
 const messageEditor = require('./components/message-editor')
 const sidebar = require('./components/sidebar')
+const accountSettings = require('./components/account-settings')
 
 // create app
 const app = choo()
@@ -81,6 +82,16 @@ app.use(sidebar.store)
       <main>
         ${messages.component(state, emit)}
         ${state.messages.list !== null ? messageEditor.component(state, emit) : html`<span></span>`}
+      </main>
+    </div>`
+  })
+
+  // server account settings page
+  app.route('/servers/:host/account', (state, emit) => {
+    return html`<div class=${prefix}>
+      ${sidebar.component(state, emit)}
+      <main>
+        ${accountSettings.component(state, emit)}
       </main>
     </div>`
   })

--- a/site/js/components/account-settings.css
+++ b/site/js/components/account-settings.css
@@ -1,0 +1,77 @@
+:host {
+  background: var(--gray-900);
+  max-width: 700px;
+
+  padding-right: 80px;
+  box-shadow: 0 0 16px -4px #00000044;
+
+  h1 {
+    margin-left: 180px;
+  }
+
+  .styled-input {
+    display: flex;
+    flex-direction: row;
+
+    & > label {
+      width: 150px;
+      line-height: 50px;
+
+      margin: 0;
+      margin-right: 14px;
+
+      text-align: right;
+    }
+
+    & > p {
+      line-height: 1.6;
+      margin-left: 13px;
+    }
+
+    & > .styled-button.no-bg {
+      color: var(--red);
+    }
+  }
+
+  & > .avatar {
+    flex-wrap: wrap;
+
+    & > img {
+      border-radius: 4px;
+      width: 50px;
+      height: 50px;
+
+      margin-left: 24px;
+    }
+
+    & + p {
+      margin-left: 180px;
+      color: var(--gray-300);
+
+      a {
+        color: var(--gray-100);
+      }
+    }
+  }
+
+  & > .submit {
+    display: block;
+
+    margin-top: 80px;
+    margin-left: auto;
+    margin-right: 0;
+    float: right;
+
+    & > .status {
+      color: var(--red);
+    }
+
+    & > .save {
+      margin-left: 24px;
+      padding: 14px 24px;
+
+      font-size: 18px;
+      background: var(--red);
+    }
+  }
+}

--- a/site/js/components/account-settings.js
+++ b/site/js/components/account-settings.js
@@ -22,7 +22,7 @@ const component = (state, emit) => {
       statusEl.innerText = 'Saving...'
 
       try {
-        const { avatarURL } = await api.post(state.params.host, 'account-settings', {
+        const { avatarURL } = await api.post(state, 'account-settings', {
           email,
           sessionID: state.session.id,
         })

--- a/site/js/components/account-settings.js
+++ b/site/js/components/account-settings.js
@@ -22,20 +22,24 @@ const component = (state, emit) => {
       statusEl.innerText = 'Saving...'
 
       try {
-        await api.post(state.params.host, 'account-settings', {
+        const { avatarURL } = await api.post(state.params.host, 'account-settings', {
           email,
           sessionID: state.session.id,
         })
 
-        state.session.user.email = email
+        Object.assign(state.session.user, {
+          email, avatarURL,
+        })
+
+        emit('render')
+        setTimeout(() => {
+          statusEl.innerText = 'Saved'
+        }, 25)
       } catch (error) {
         statusEl.innerText = 'Error!'
         console.error(error)
       }
     }
-
-    // go back
-    history.go(-1)
   }
 
   return html`<div class='page ${prefix}'>

--- a/site/js/components/account-settings.js
+++ b/site/js/components/account-settings.js
@@ -1,0 +1,72 @@
+// sidebar component
+const html = require('choo/html')
+const css = require('sheetify')
+const { api } = require('../util')
+
+const prefix = css('./account-settings.css')
+
+const component = (state, emit) => {
+  if (!state.session) {
+    // not logged in
+    return html`<div class='page'>
+      Not logged in.
+    </div>`
+  }
+
+  const save = async () => {
+    const email = document.getElementById(prefix + 'email').value.trim() || null
+    const statusEl = document.querySelector(`.${prefix} > .submit > .status`)
+
+    // update if unchanged
+    if (email !== state.session.user.email) {
+      statusEl.innerText = 'Saving...'
+
+      try {
+        await api.post(state.params.host, 'account-settings', {
+          email,
+          sessionID: state.session.id,
+        })
+
+        state.session.user.email = email
+      } catch (error) {
+        statusEl.innerText = 'Error!'
+        console.error(error)
+      }
+    }
+
+    // go back
+    history.go(-1)
+  }
+
+  return html`<div class='page ${prefix}'>
+    <h1>Account settings <span class='subtitle'>for ${state.params.host}</span></h1>
+
+    <div class='styled-input'>
+      <label for='${prefix}username'>Username</label>
+      <input id='${prefix}username' type='text' disabled value=${state.session.user.username}/>
+    </div>
+
+    <div class='styled-input'>
+      <label>Password</label>
+      <button class='styled-button no-bg' onclick=${() => alert('not implemented')}>Change password</button>
+    </div>
+
+    <div class='styled-input avatar'>
+      <label for='${prefix}email'>Avatar</label>
+
+      <input id='${prefix}email' type='email' placeholder='Email address' value=${state.session.user.email || ''}/>
+      <img src=${state.session.user.avatarURL}/>
+    </div>
+
+    <p>
+      We use <a class='link' href='https://www.libravatar.org/'>Libravatar</a> for avatars, which falls back to Gravatar.
+    </p>
+
+    <div class='submit'>
+      <span class='status'></span>
+      <button class='styled-button save' onclick=${save}>Save</button>
+    </div>
+  </div>`
+}
+
+module.exports = { component, prefix }

--- a/site/js/components/message-group.js
+++ b/site/js/components/message-group.js
@@ -68,8 +68,6 @@ const updateTimes = () => {
 }
 
 const component = (state, emit, group) => {
-  const avatarURL = 'https://seccdn.libravatar.org/avatar/md5-hash-of-author-email' // TODO
-
   function timeEl(date) {
     const { needsUpdate, string } = stringifyDate(date)
 
@@ -81,7 +79,7 @@ const component = (state, emit, group) => {
   }
 
   return html`<div class=${prefix} id=${group.id}>
-    <img class='icon' src=${avatarURL}/>
+    <img class='icon' src=${group.authorAvatarURL}/>
     <div class='content'>
       <div class='info'>
         <div class='username'>${group.authorUsername}</div>

--- a/site/js/components/messages.js
+++ b/site/js/components/messages.js
@@ -28,6 +28,7 @@ const groupMessages = (msgs, startingGroups = []) => {
       groups.push({
         authorID: msg.authorID,
         authorUsername: msg.authorUsername,
+        authorAvatarURL: msg.authorAvatarURL,
         messages: [ msg ],
         id: 'msg-group-' + msg.date,
       })

--- a/site/js/components/sidebar.css
+++ b/site/js/components/sidebar.css
@@ -201,7 +201,10 @@
 
         & > .username {
           color: var(--gray-100);
-          text-decoration: none;
+          cursor: pointer;
+          text-decoration: underline;
+
+          margin-left: 5px;
         }
       }
 

--- a/site/js/components/sidebar.js
+++ b/site/js/components/sidebar.js
@@ -345,7 +345,10 @@ const component = (state, emit) => {
       ${state.params.host ? (() => {
         if (state.session) {
           return html`<div class='session'>
-            <div class='text'>Logged in as <a class='username'>${state.session.user.username}</a></div>
+            <div class='text'>
+              Logged in as
+              <a class='username' onclick=${() => emit('pushState', `/servers/${state.params.host}/account`)}>${state.session.user.username}</a>
+            </div>
 
             <button onclick=${() => emit('sidebar.logout')}>Logout</button>
           </div>`

--- a/site/js/util/api.js
+++ b/site/js/util/api.js
@@ -12,6 +12,7 @@ async function fetchHelper(state, path, fetchConfig = {}) {
     host = state.params.host
   } else {
     console.warn('Host string provided, not state object')
+    console.trace()
   }
 
   const protocol = secure ? 'https://' : '//'

--- a/site/js/util/api.js
+++ b/site/js/util/api.js
@@ -3,13 +3,15 @@
 async function fetchHelper(state, path, fetchConfig = {}) {
   // Quick guarding, just in case e.g. host is fetched from a variable
   // whose value is undefined.
-  if (!state) throw new Error('No state/host argument given')
+  if (!state) throw new Error('No state argument given')
   if (!path) throw new Error('No path argument given')
 
   let secure = false, host = state
   if (typeof state === 'object') {
     secure = state.secure
     host = state.params.host
+  } else {
+    console.warn('Host string provided, not state object')
   }
 
   const protocol = secure ? 'https://' : '//'

--- a/site/js/util/modal.css
+++ b/site/js/util/modal.css
@@ -63,56 +63,6 @@
 
     min-height: 24px;
   }
-
-  & .styled-input {
-    margin-bottom: 16px;
-
-    & label {
-      display: block;
-      color: var(--gray-300);
-
-      font-weight: bold;
-      font-size: 16px;
-
-      text-transform: uppercase;
-      margin-bottom: 4px;
-      margin-left: 13px;
-
-      -webkit-touch-callout: none;
-      -webkit-user-select: none;
-         -moz-user-select: none;
-              user-select: none;
-    }
-
-    & input {
-      width: 280px;
-      padding: 13px 16px;
-
-      font-family: inherit;
-      font-size: 18px;
-
-      color: var(--gray-100);
-      background: var(--gray-900);
-
-      border: 0;
-      border-bottom: 1px solid var(--gray-500);
-      &:focus { border-color: var(--blue); }
-    }
-  }
-
-  .styled-button {
-    padding: 10px 16px;
-    margin-left: 3px;
-
-    background: var(--blue);
-    border-radius: 4px;
-    border: none;
-
-    font-size: 14px;
-    color: var(--gray-900);
-
-    cursor: pointer;
-  }
 }
 
 #modal-page-cover.visible {

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,6 +635,12 @@ css-extract@^1.2.0:
     static-module "^1.3.0"
     through2 "^2.0.1"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -779,6 +785,37 @@ es3ify@^0.1.3:
     jstransform "~3.0.0"
     through "~2.3.4"
 
+es5-ext@^0.10.14, es5-ext@^0.10.30, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2:
+  version "0.10.37"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.37.tgz#0ee741d148b80069ba27d020393756af257defc3"
+  dependencies:
+    es6-iterator "~2.0.1"
+    es6-symbol "~3.1.1"
+
+es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -864,6 +901,13 @@ esutils@~1.0.0:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 events@~1.1.0:
   version "1.1.1"
@@ -1374,6 +1418,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -1501,6 +1549,12 @@ lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
 
+lru-queue@0.1:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+  dependencies:
+    es5-ext "~0.10.2"
+
 map-limit@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/map-limit/-/map-limit-0.0.1.tgz#eb7961031c0f0e8d001bf2d56fab685d58822f38"
@@ -1517,6 +1571,19 @@ md5.js@^1.3.4:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+memoizee@^0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.11.tgz#bde9817663c9e40fdb2a4ea1c367296087ae8c8f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.30"
+    es6-weak-map "^2.0.2"
+    event-emitter "^0.3.5"
+    is-promise "^2.1"
+    lru-queue "0.1"
+    next-tick "1"
+    timers-ext "^0.1.2"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -1721,6 +1788,10 @@ nedb@^1.8.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+next-tick@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -2572,6 +2643,13 @@ timers-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
   dependencies:
     process "~0.11.0"
+
+timers-ext@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.2.tgz#61cc47a76c1abd3195f14527f978d58ae94c5204"
+  dependencies:
+    es5-ext "~0.10.14"
+    next-tick "1"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Resolves #101 :tada:  
This PR merges into `componentize`, **not** master, to help with merge conflicts. It therefore blocks it.

Uses libravatar, and stores email addresses on the server. You get a default retro avatar based on the md5 hash of your user ID:

![image](https://user-images.githubusercontent.com/9429556/34255669-ad206e14-e649-11e7-890e-4871e1d0c970.png)

And you can use the account settings page (accessed by clicking your username in the session info area in the sidebar) at `/servers/:host/account-settings` to edit the email address associated with your account.

![image](https://user-images.githubusercontent.com/9429556/34255718-e8967ae2-e649-11e7-8735-9004fb5d11e5.png)

Note that "Change password" just runs `alert('not implemented')`.

Any further messages from you will take your avatar URL with them (`msg.authorAvatarURL`):

![image](https://user-images.githubusercontent.com/9429556/34255754-02535ae0-e64a-11e7-93a0-e441ecda87ee.png)

### API changes

User objects now have a string `authorAvatarURL` field. Likewise, message objects have `authorAvatarURL`, set at the time they are created. Note: in the database these 'avatar URLs' don't exist - they are stored as `email` and `authorEmail` (null, by default) and avatar URLs are only created when the object is seralized.

**New endpoint!** `POST /api/account-settings { email: String, sessionID: String }`. Returns `{ success: true, avatarURL: ... }`

`/api/session/:sessionID` now gives you `user.email`.