### PR TITLE
Session deletion

### DIFF
--- a/api.js
+++ b/api.js
@@ -1232,4 +1232,19 @@ module.exports = async function attachAPI(app, {wss, db}) {
       }
     }
   }, 10 * 1000) // Every 10s.
+
+  const pruneOldSessions = async function() {
+    // Remove old sessions - any that are at least 30 days old.
+
+    const maximumLifetime = 30 * 24 * 60 * 60 * 1000
+
+    await db.sessions.remove({
+      $where: function() {
+        return Date.now() - this.dateCreated > maximumLifetime
+      }
+    }, {multi: true})
+  }
+
+  setInterval(pruneOldSessions, 5 * 60 * 1000) // Every 5min.
+  pruneOldSessions()
 }

--- a/api.js
+++ b/api.js
@@ -184,25 +184,8 @@ module.exports = async function attachAPI(app, {wss, db}) {
     sessionDetail: async s => {
       const user = await getUserBySessionID(s._id)
 
-      let authorizationMessage, userAuthorized
-      if (await shouldUseAuthorization()) {
-        userAuthorized = await isUserAuthorized(user._id)
-        if (!userAuthorized) {
-          authorizationMessage = (
-            await db.settings.findOne({_id: serverSettingsID})
-          ).authorizationMessage
-        }
-      }
-
       return Object.assign(await serialize.sessionBrief(s), {
-        user: await serialize.user(user),
-
-        // This is redundant since it's already stored on the user, but it's
-        // nice to have anyways - it makes the authorizationMessage property
-        // seem less out of place.
-        userAuthorized,
-
-        authorizationMessage
+        user: await serialize.user(user, user)
       })
     },
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,6 +161,19 @@ Attempts to log in as a user, creating a new session. Returns `{success: true, s
 
 Returns `{success: true, user}` if successful, where `user` is a [user object](#user-object) of the user which the session represents. This endpoint is useful when grabbing information about the logged in user (e.g. at the startup of a client program, which may display the logged in user's username in a status bar).
 
+### POST `/api/delete-sessions`
+
+- Parameters:
+  * `sessionIDs`: (via body; array of strings) the IDs of the sessions to be deleted.
+
+Deletes the given sessions (using their IDs will no longer work). Passing just one session ID is fine. Returns `{success: true}` if successful.
+
+### GET `/api/user-session-list`
+
+- Parameters:
+  * `sessionID`: (via body; string) the session ID to use. The session must exist.
+
+Returns `{success: true, sessions}` if successful, where `sessions` is an array of [(brief) session objects](#session-object). All sessions which are logged into the same user as the given session (via `sessionID`) are returned.
 
 ## WebSocket events
 
@@ -247,6 +260,19 @@ Some endpoints return a more detailed channel object. (Particularly, `/api/chann
 Some endpoints return further information when a session ID is given (e.g. `/api/channel-list?sessionID=..`). This information is specific to the particular logged in user, and includes the following:
 
 * `unreadMessageCount`: (number) the number of "unread" messages, capped at 200. Unread messages are simply messages which were sent more recently than the last time the channel was marked as read. (Channels are marked as read whenever the user sends a message, and can also be set manually/by the client using the `/api/mark-channel-as-read` endpoint.)
+
+### Session Object
+
+A login session. As with [channel objects](#channel-object), there are two variants of sessions; brief and detailed ones.
+
+All returned session objects have these properties:
+
+* `id`: (string) the ID of the session. This is a unique string in [version 4 UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_%28random%29), and is used to access and act as the account that the session was created for.
+* `dateCreated`: (number) the date the session was [created](#post-apilogin).
+
+Detailed sessions also have these properties:
+
+* `user`: ([user](#user-object)) the user that the session was created for.
 
 
 ## Etc.

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -145,6 +145,10 @@ body {
       text-decoration: underline;
     }
   }
+
+  &:not(.no-bg) {
+    &.red { background-color: var(--red); color: white; }
+  }
 }
 
 a:any-link.link {

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -59,6 +59,7 @@ app.use((state, emitter) => {
 
 app.use(messages.store)
 app.use(sidebar.store)
+app.use(accountSettings.store)
 
 for (const [ name, s ] of Object.entries(srvSettings)) {
   if (s.store) {

--- a/site/src/components/account-settings.css
+++ b/site/src/components/account-settings.css
@@ -85,5 +85,12 @@
   .session-id {
     color: var(--gray-300);
     font-family: monospace;
+    white-space: nowrap;
+    filter: blur(6px);
+
+    &:hover {
+      filter: blur(0);
+      transition: filter 2s;
+    }
   }
 }

--- a/site/src/components/account-settings.css
+++ b/site/src/components/account-settings.css
@@ -60,6 +60,7 @@
     margin-top: 80px;
     margin-left: auto;
     margin-right: 0;
+    margin-bottom: 20px;
     float: right;
 
     & > .status {
@@ -71,7 +72,18 @@
       padding: 14px 24px;
 
       font-size: 18px;
-      background: var(--red);
+      background: var(--green);
     }
+  }
+
+  h2 {
+    clear: right;
+    border-top: 1px solid var(--gray-300);
+    padding-top: 4px;
+  }
+
+  .session-id {
+    color: var(--gray-300);
+    font-family: monospace;
   }
 }

--- a/site/src/components/account-settings.js
+++ b/site/src/components/account-settings.js
@@ -175,6 +175,9 @@ const component = (state, emit) => {
       <p>Loading sessions...</p>
     ` : html`
       <div>
+        <p>
+          These are your login sessions. <strong>The blurred-out codes should <em>never</em> be shared - they give <em>anybody</em> full access to your account.</strong> Old login sessions (any older than 30 days) are automatically deleted, so you'll need to login roughly once a month (if you're not the type to log out every time).
+        </p>
         <p><button
           class='styled-button red'
           onclick=${() => emit('accountSettings.deleteAllSessions')}

--- a/site/src/components/account-settings.js
+++ b/site/src/components/account-settings.js
@@ -22,6 +22,8 @@ const store = (state, emitter) => {
       sessionID: state.session.id
     })
 
+    sessions.sort((a, b) => b.dateCreated - a.dateCreated)
+
     state.accountSettings.sessionList = sessions
     state.accountSettings.fetchingSessions = false
     emitter.emit('render')

--- a/site/src/components/account-settings.js
+++ b/site/src/components/account-settings.js
@@ -9,11 +9,19 @@ const store = (state, emitter) => {
   const reset = () => state.accountSettings = {
     sessionList: null,
     fetchingSessions: false,
+    oldRoute: '/',
   }
 
   reset()
 
   emitter.on('login', () => reset())
+
+  emitter.on('route', () => {
+    if (state.accountSettings.oldRoute !== state.route) {
+      state.accountSettings.oldRoute = state.route
+      emitter.emit('accountSettings.fetchSessions')
+    }
+  })
 
   emitter.on('accountSettings.fetchSessions', async () => {
     state.accountSettings.fetchingSessions = true
@@ -48,8 +56,6 @@ const store = (state, emitter) => {
       emitter.emit('sidebar.logout')
     }
   })
-
-  reset()
 }
 
 const component = (state, emit) => {

--- a/site/src/components/message-group.js
+++ b/site/src/components/message-group.js
@@ -3,48 +3,7 @@ const css = require('sheetify')
 const raw = require('choo/html/raw')
 const html = require('choo/html')
 const mrk = require('../util/mrk')
-
-// returns 3-character month name from a Date
-const month = d => [ 'Jan', 'Feb',' Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ][d.getMonth()]
-
-// converts a milliseconds-date-number to a readable string
-// * < 60sec: just now
-// * < 30min: X mins (or 1 min)
-// * < 24hrs: X hours (or 1 hour) -- rounded, not floored
-// * > 24hrs: X days (or 1 day)
-// * > 7days: date (e.g. Apr 2)
-const stringifyDate = date => {
-  const second = 1000
-  const minute = 60 * second
-  const hour = 60 * minute
-  const day = 24 * hour
-  const week = 7 * day
-
-  const s = (t, n) => n + ' ' + t + (n === 1 ? '' : 's')
-
-  const ago = Date.now() - date
-
-  if (ago < minute) {
-    return { needsUpdate: true, string: 'Just now' }
-  }
-
-  if (ago < 30 * minute) {
-    return { needsUpdate: true, string: s('min', Math.round(ago / minute)) }
-  }
-
-  if (ago < 24 * hour) {
-    return { needsUpdate: true, string: s('hour', Math.round(ago / hour)) }
-  }
-
-  if (ago > week) {
-    const d = new Date(date)
-    return { needsUpdate: false, string: month(d) + d.getDate() }
-  }
-
-  if (ago > day) {
-    return { needsUpdate: true, string: s('day', Math.round(ago / day)) }
-  }
-}
+const { timeAgo } = require('../util/date')
 
 css('prismjs/themes/prism.css')
 const prefix = css('./message-group.css')
@@ -55,7 +14,7 @@ const updateTimes = () => {
   const times = document.querySelectorAll(`.${prefix} time.needs-update`)
 
   for (const time of times) {
-    const date = stringifyDate(parseInt(time.dataset.date))
+    const date = timeAgo(parseInt(time.dataset.date))
 
     if (!date.needsUpdate) {
       // we no longer need to update this time
@@ -73,7 +32,7 @@ const component = (state, emit, group) => {
   }
 
   function timeEl(date) {
-    const { needsUpdate, string } = stringifyDate(date)
+    const { needsUpdate, string } = timeAgo(date)
 
     return html`<time class=${needsUpdate ? 'needs-update': ''}
          title=${new Date(date).toLocaleString()}

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -343,9 +343,9 @@ const store = (state, emitter) => {
   emitter.on('logout', () => emitter.emit('sidebar.fetchchannels'))
 
   async function loadSessionID(sessionID) {
-    const result = await api.get(state, 'session/' + sessionID, {sessionID})
-    if (result.user) {
-      state.session = { id: sessionID, user: result.user }
+    const { session } = await api.get(state, 'session/' + sessionID, {sessionID})
+    if (session.user) {
+      state.session = { id: sessionID, user: session.user }
 
       // If the server requires authorization, we'll set the sessionAuthorized
       // state value to whether or not the logged in user is authorized (which
@@ -353,11 +353,11 @@ const store = (state, emitter) => {
       // authorization, we'll just set sessionAuthorized to true, since
       // acting as though we're authorized is what we want.
       if (state.serverRequiresAuthorization) {
-        if (result.userAuthorized) {
+        if (session.userAuthorized) {
           state.sessionAuthorized = true
         } else {
           state.sessionAuthorized = false
-          state.authorizationMessage = result.authorizationMessage
+          state.authorizationMessage = session.authorizationMessage
         }
       } else {
         state.sessionAuthorized = true

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -326,7 +326,13 @@ const store = (state, emitter) => {
   })
 
   // logout
-  emitter.on('sidebar.logout', () => {
+  emitter.on('sidebar.logout', async () => {
+    if (state.session) {
+      await api.post(state, 'delete-sessions', {
+        sessionIDs: [state.session.id]
+      })
+    }
+
     state.session = null
     storage.set('sessionID@' + state.params.host, null)
     emitter.emit('render')

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -353,7 +353,8 @@ const store = (state, emitter) => {
       // authorization, we'll just set sessionAuthorized to true, since
       // acting as though we're authorized is what we want.
       if (state.serverRequiresAuthorization) {
-        state.sessionAuthorized = result.user.authorized
+        console.log(session)
+        state.sessionAuthorized = session.user.authorized
       } else {
         state.sessionAuthorized = true
       }

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -353,7 +353,6 @@ const store = (state, emitter) => {
       // authorization, we'll just set sessionAuthorized to true, since
       // acting as though we're authorized is what we want.
       if (state.serverRequiresAuthorization) {
-        console.log(session)
         state.sessionAuthorized = session.user.authorized
       } else {
         state.sessionAuthorized = true

--- a/site/src/util/date.js
+++ b/site/src/util/date.js
@@ -38,6 +38,4 @@ module.exports.timeAgo = function(date) {
   if (ago > day) {
     return { needsUpdate: true, string: s('day', Math.round(ago / day)) }
   }
-
-  console.log('uhhh', date)
 }

--- a/site/src/util/date.js
+++ b/site/src/util/date.js
@@ -1,0 +1,43 @@
+const second = 1000
+const minute = 60 * second
+const hour = 60 * minute
+const day = 24 * hour
+const week = 7 * day
+
+// returns 3-character month name from a Date
+const month = d => [ 'Jan', 'Feb',' Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ][d.getMonth()]
+
+// converts a milliseconds-date-number to a readable string
+// * < 60sec: just now
+// * < 30min: X mins (or 1 min)
+// * < 24hrs: X hours (or 1 hour) -- rounded, not floored
+// * > 24hrs: X days (or 1 day)
+// * > 7days: date (e.g. Apr 2)
+module.exports.timeAgo = function(date) {
+  const s = (t, n) => n + ' ' + t + (n === 1 ? '' : 's')
+
+  const ago = Date.now() - date
+
+  if (ago < minute) {
+    return { needsUpdate: true, string: 'Just now' }
+  }
+
+  if (ago < 30 * minute) {
+    return { needsUpdate: true, string: s('min', Math.round(ago / minute)) }
+  }
+
+  if (ago < 24 * hour) {
+    return { needsUpdate: true, string: s('hour', Math.round(ago / hour)) }
+  }
+
+  if (ago > week) {
+    const d = new Date(date)
+    return { needsUpdate: false, string: month(d) + d.getDate() }
+  }
+
+  if (ago > day) {
+    return { needsUpdate: true, string: s('day', Math.round(ago / day)) }
+  }
+
+  console.log('uhhh', date)
+}


### PR DESCRIPTION
This PR contains two Big Things: automatic deletion of old sessions (fixes #43) and manual deletion of sessions. It also contains a few changes to the API and related documentation.

**Automatic deletion of old sessions** fixes #43 by pruning sessions that are at least 30 days old every five minutes and on server startup.

**Manual deletion of sessions** is a new feature which lets any user delete any sessions logged into their account. It looks like this:

![List of sessions under new section "Login sessions" in account settings page, each showing the (blurred out) session ID and a "delete" button](https://user-images.githubusercontent.com/9948030/34418300-b6eac590-ebd3-11e7-8ca8-409e7a81fb10.png)

You (and only you) can view and delete sessions from your account settings page.

Relevant API documentation can be found in commit a1396a7447fcb15e082e6ac221709309f2c9b823.

This is blocked by PR #141; I intend to update `/session/:sessionID` to return session objects, but I can't change it right now because #141 already changes the endpoint.